### PR TITLE
Add typedoc-cookie-consent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This plugin is needed after version [v0.26.0](https://github.com/TypeStrong/type
 | Option                  | Default | Description                                                                                |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------ |
 | gaID     | `undefined`  | The `gaID` of your Google Analytics |
+| gaProperties | `{}`     | Optional properties that will be attached to the Google Analytics script element |
 
 ## Changelog
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -6,11 +6,17 @@ function addGaOptionParameter(app: Application): void {
         help: 'Set the Google Analytics tracking ID and activate tracking code',
         type: ParameterType.String
     });
+    app.options.addDeclaration({
+        name: 'gaCookieConsentCategory',
+        help: 'If set, the tracking script will be controlled by the typedoc-cookie-consent plugin',
+        type: ParameterType.String
+    });
 }
 
 function addGaScript(app: Application): void {
     app.renderer.hooks.on('body.end', () => {
         const gaID = app.options.getValue('gaID') as string;
+        const gaCategory = app.options.getValue('gaCookieConsentCategory') as string;
         if (gaID) {
             const script = `
 window.dataLayer = window.dataLayer || [];
@@ -23,7 +29,7 @@ gtag('config', '${gaID}');
                     async: true,
                     src: `https://www.googletagmanager.com/gtag/js?id=${gaID}`
                 }),
-                JSX.createElement('script', null, JSX.createElement(JSX.Raw, { html: script }))
+                JSX.createElement('script', gaCategory ? { type: "text/plain", ["data-category"]: gaCategory } : null, JSX.createElement(JSX.Raw, { html: script }))
             ]);
         }
         return JSX.createElement(JSX.Fragment, null);

--- a/source/index.ts
+++ b/source/index.ts
@@ -7,16 +7,17 @@ function addGaOptionParameter(app: Application): void {
         type: ParameterType.String
     });
     app.options.addDeclaration({
-        name: 'gaCookieConsentCategory',
-        help: 'If set, the tracking script will be controlled by the typedoc-cookie-consent plugin',
-        type: ParameterType.String
+        name: 'gaProperties',
+        help: 'Optional properties that will be attached to the Google Analytics script element',
+        type: ParameterType.Object,
+        defaultValue: {}
     });
 }
 
 function addGaScript(app: Application): void {
     app.renderer.hooks.on('body.end', () => {
         const gaID = app.options.getValue('gaID') as string;
-        const gaCategory = app.options.getValue('gaCookieConsentCategory') as string;
+        const gaProperties = app.options.getValue('gaProperties') as object | null;
         if (gaID) {
             const script = `
 window.dataLayer = window.dataLayer || [];
@@ -29,7 +30,7 @@ gtag('config', '${gaID}');
                     async: true,
                     src: `https://www.googletagmanager.com/gtag/js?id=${gaID}`
                 }),
-                JSX.createElement('script', gaCategory ? { type: "text/plain", ["data-category"]: gaCategory } : null, JSX.createElement(JSX.Raw, { html: script }))
+                JSX.createElement('script', gaProperties, JSX.createElement(JSX.Raw, { html: script }))
             ]);
         }
         return JSX.createElement(JSX.Fragment, null);


### PR DESCRIPTION
It adds a new option that allows the https://github.com/vpalmisano/typedoc-cookie-consent plugin to control the GA script execution.